### PR TITLE
Store seperate congfig values for date and time.

### DIFF
--- a/planterbox/__init__.py
+++ b/planterbox/__init__.py
@@ -285,8 +285,12 @@ class Planterbox(Plugin):
     def register(self):
         super(Planterbox, self).register()
         if 'start_time' not in self.config._mvd:
-            start_time = datetime.now().isoformat()
+            start_date = datetime.now().strftime("%Y-%m-%d")
+            start_time = datetime.now().strftime("%H_%M_%S")
+            
+            self.config._mvd['start_date'] = [start_date]
             self.config._mvd['start_time'] = [start_time]
+            self.config._items.append(('start_date', start_date))
             self.config._items.append(('start_time', start_time))
 
     def makeSuiteFromFeature(self, module, feature_path,

--- a/planterbox/__init__.py
+++ b/planterbox/__init__.py
@@ -285,13 +285,13 @@ class Planterbox(Plugin):
     def register(self):
         super(Planterbox, self).register()
         if 'start_time' not in self.config._mvd:
-            start_date = datetime.now().strftime("%Y-%m-%d")
-            start_time = datetime.now().strftime("%H_%M_%S")
             
-            self.config._mvd['start_date'] = [start_date]
-            self.config._mvd['start_time'] = [start_time]
-            self.config._items.append(('start_date', start_date))
-            self.config._items.append(('start_time', start_time))
+            start_datetime = datetime.now()
+            
+            self.config._mvd['start_date'] = [start_datetime.strftime("%Y-%m-%d")]
+            self.config._mvd['start_time'] = [start_datetime.strftime("%H_%M_%S")]
+            self.config._items.append(('start_date', start_datetime.strftime("%Y-%m-%d")))
+            self.config._items.append(('start_time', start_datetime.strftime("%H_%M_%S")))
 
     def makeSuiteFromFeature(self, module, feature_path,
                              scenario_indexes=None):


### PR DESCRIPTION
* Capture separate
![screenshot 2015-07-20 10 12 33](https://cloud.githubusercontent.com/assets/231390/8782229/de3b10ac-2ec8-11e5-8f18-7cb9ac24575e.png)
 values for start_date and start_time to better match existing screeenshot-ing dir structure.