### PR TITLE
Planterbox tests on qa.tool has been acting up.

### DIFF
--- a/planterbox/plugin.py
+++ b/planterbox/plugin.py
@@ -80,7 +80,7 @@ class Planterbox(Plugin):
 
         try:
             feature_package_name = name_from_path(
-                os.path.dirname(feature_path))
+                os.path.dirname(feature_path)[0])
             feature_module = object_from_name(feature_package_name)[1]
         except:
             return event.loader.failedImport(feature_path)

--- a/planterbox/plugin.py
+++ b/planterbox/plugin.py
@@ -80,7 +80,7 @@ class Planterbox(Plugin):
 
         try:
             feature_package_name = name_from_path(
-                os.path.dirname(feature_path)[0])
+                os.path.dirname(feature_path))[0]
             feature_module = object_from_name(feature_package_name)[1]
         except:
             return event.loader.failedImport(feature_path)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requires = [
-    "nose2==0.5.0",
+    "nose2>=0.6.0",
     "mock",
 ]
 


### PR DESCRIPTION
Talked with nick, and he discovered "
nose2 changed their API... `name_from_path` is now pretty different"
This is a fix for that.